### PR TITLE
Match current working directory to Atom project

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -22,6 +22,8 @@ module.exports =
 
   toggle: (editor) ->
     return unless editor
+    project = editor.buffer.file?.getParent() ? atom.project.getDirectories()[0]
+    try process.chdir project?.path
 
     if @view?.isAlive()
       @view.destroy()


### PR DESCRIPTION
The current working directory was previously set to `/`, which is of no use when working with relative paths in some previewed files. This commit sets the working directory to match that of the file being previewed, or else the current Atom project.

Signed-off-by: Daniel Bayley <daniel.bayley@me.com>